### PR TITLE
Add --update (-u) flag to auto-accept snapshot changes

### DIFF
--- a/toolproof/src/main.rs
+++ b/toolproof/src/main.rs
@@ -558,6 +558,20 @@ async fn main_inner() -> Result<(), ()> {
                     );
                     println!("{}", msg.green());
                     Ok(success)
+                } else if universe.ctx.params.update {
+                    if let Err(e) = std::fs::write(&file.file_path, &output_doc) {
+                        eprintln!("Unable to write updated snapshot to disk.\n{e}");
+                        return Err(HoldingError::TestFailure);
+                    }
+                    let msg = format!(
+                        "{}{}{}  {}",
+                        "✓ ".green(),
+                        dur.green().dimmed(),
+                        &file.name.green(),
+                        "(snapshot updated)".cyan()
+                    );
+                    println!("{}", msg);
+                    Ok(ToolproofTestSuccess::Passed { attempts: 0 })
                 } else {
                     println!(
                         "{}",
@@ -577,7 +591,7 @@ async fn main_inner() -> Result<(), ()> {
                         );
                         println!(
                             "\n{}",
-                            "Run in interactive mode (-i) to accept new snapshots\n"
+                            "Run in interactive mode (-i) or with --update (-u) to accept new snapshots\n"
                                 .bright_red()
                                 .bold()
                         );

--- a/toolproof/src/options.rs
+++ b/toolproof/src/options.rs
@@ -107,6 +107,12 @@ fn get_cli_matches() -> ArgMatches {
         )
         .arg(
             arg!(
+                -u --update ... "Automatically accept all snapshot changes"
+            )
+            .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            arg!(
                 -s --skiphooks ... "Skip running any hooks (e.g. before_all)"
             )
             .action(clap::ArgAction::SetTrue),
@@ -202,6 +208,10 @@ pub struct ToolproofParams {
 
     /// Run all tests when in interactive mode
     pub all: bool,
+
+    /// Automatically accept all snapshot changes
+    #[setting(env = "TOOLPROOF_UPDATE")]
+    pub update: bool,
 
     /// Run a specific test
     #[setting(env = "TOOLPROOF_RUN_NAME")]
@@ -303,6 +313,10 @@ impl ToolproofParams {
 
         if cli_matches.get_flag("all") {
             self.all = true;
+        }
+
+        if cli_matches.get_flag("update") {
+            self.update = true;
         }
 
         if cli_matches.get_flag("skiphooks") {

--- a/toolproof/test_suite/base/snapshot.toolproof.yml
+++ b/toolproof/test_suite/base/snapshot.toolproof.yml
@@ -56,7 +56,7 @@ steps:
       ╎
       ╎--- END SNAPSHOT CHANGE ---
       ╎
-      ╎Run in interactive mode (-i) to accept new snapshots
+      ╎Run in interactive mode (-i) or with --update (-u) to accept new snapshots
       ╎
       ╎
       ╎Finished running tests

--- a/toolproof/test_suite/base/snapshot_update.toolproof.yml
+++ b/toolproof/test_suite/base/snapshot_update.toolproof.yml
@@ -1,0 +1,39 @@
+name: Snapshots can be auto-updated with --update flag
+
+steps:
+  - step: I have a "my_test.toolproof.yml" file with the content {yaml}
+    yaml: |-
+      name: Inner snapshot test with wrong content
+
+      steps:
+        - I run 'echo "Aenean eu leo quam"'
+        - snapshot: stdout
+          snapshot_content: |-
+            ╎bad
+  - I run "%toolproof_path% --porcelain -u"
+  - snapshot: stdout
+    snapshot_content: |-
+      ╎
+      ╎Running tests
+      ╎
+      ╎✓ Inner snapshot test with wrong content  (snapshot updated)
+      ╎
+      ╎Finished running tests
+      ╎
+      ╎Total passing tests: 1
+      ╎Passed after retry: 0
+      ╎Failing tests: 0
+      ╎Skipped tests: 0
+      ╎
+      ╎All tests passed
+  - step: I have a "expected_updated.toolproof.yml" file with the content {yaml}
+    yaml: |-
+      name: Inner snapshot test with wrong content
+
+      steps:
+        - I run 'echo "Aenean eu leo quam"'
+        - snapshot: stdout
+          snapshot_content: |-
+            ╎Aenean eu leo quam
+  - I run "diff my_test.toolproof.yml expected_updated.toolproof.yml"
+  - stderr should be empty


### PR DESCRIPTION
- Adds a `-u` / `--update` CLI flag (and `TOOLPROOF_UPDATE` env var) that automatically accepts all snapshot changes without interactive prompts, writing updated YAML files to disk inline during the test run.
- Updates the non-interactive hint message to mention `--update (-u)` alongside `-i`.
- Adds a new test (`snapshot_update.toolproof.yml`) that verifies the flag auto-updates a mismatched snapshot on disk and reports the test as passing.

## Motivation

When snapshots change, toolproof currently requires either interactive terminal review (`-i`) or fails the run. This makes it unusable for AI coding agents and headless CI that want to update snapshots in place. The `--update` / `-u` naming follows the established convention from Jest (`--updateSnapshot` / `-u`), Vitest (`--update` / `-u`), and pytest (`--snapshot-update`).
